### PR TITLE
Fixed socket.io "echo" and related animation

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ io.on('connection', socket => {
   })
   io.emit('users', users)
   socket.on('played note', key => {
-    io.emit('played', key)
+    socket.broadcast.emit('played', key)
   })
 })
 

--- a/src/js/piano.js
+++ b/src/js/piano.js
@@ -6,9 +6,9 @@ const socket = io()
 
 socket.on('played', key => {
   const $key = document.querySelector(`[data-note='${key}']`) || ''
+  notes[key].play()
   $key.classList.add('active')
   setTimeout(() => $key.classList.remove('active'), 100)
-  notes[key].play()
 })
 
 socket.on('users', count => {
@@ -51,6 +51,8 @@ const addTapEvents = notes => {
       socket.emit('played note', note)
       notes[note].play()
       lastKeyPlayed = note
+      key.classList.add('active')
+      setTimeout(() => key.classList.remove('active'), 100)
     }
 
     let handlerMouseMove = e => {


### PR DESCRIPTION
Server uses 'broadcast' instead of 'emit' to send notes to all other players to avoid the echo.
Fixed key state (animation) to go into the "active" state during onmousedown event.